### PR TITLE
fix: fix the tray icon not showing after package

### DIFF
--- a/electron/os/tray.ts
+++ b/electron/os/tray.ts
@@ -1,9 +1,19 @@
 import { Tray, Menu, shell, dialog, BrowserWindow } from 'electron'
 import { setWindowVisile } from '../utils/window'
 import { config } from './shortcuts'
+import path from 'node:path'
+
+const isProd = process.env.production
+
+function getTrayImagePath() {
+  if (isProd) {
+    return path.join(process.resourcesPath, 'assets/icon/icon24.png')
+  }
+  return 'assets/icon/icon24.png'
+}
 
 export default (win: BrowserWindow) => {
-  const tray = new Tray('assets/icon/icon24.png')
+  const tray = new Tray(getTrayImagePath())
   const contextMenu = Menu.buildFromTemplate([
     {
       label: 'Feedback',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21942252/233053995-d60268a2-6a8e-4be9-b14d-049209cf4b22.png)

BTY, maybe we need add a `exit` button.