### PR TITLE
Fix the link of Linux badge in README

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -21,7 +21,7 @@
     <a href="https://github.com/onepointAI/onepoint/releases/latest">
       <img alt="Windows" src="https://img.shields.io/badge/-Windows-blue?style=flat-square&logo=windows&logoColor=white" />
     </a>
-    <a href="https://github.com/onepointAI/onepointreleases/latest">
+    <a href="https://github.com/onepointAI/onepoint/releases/latest">
       <img alt="Linux" src="https://img.shields.io/badge/-Linux-yellow?style=flat-square&logo=linux&logoColor=white" />
     </a>
   </div>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
     <a href="https://github.com/onepointAI/onepoint/releases/latest">
       <img alt="Windows" src="https://img.shields.io/badge/-Windows-blue?style=flat-square&logo=windows&logoColor=white" />
     </a>
-    <a href="https://github.com/onepointAI/onepointreleases/latest">
+    <a href="https://github.com/onepointAI/onepoint/releases/latest">
       <img alt="Linux" src="https://img.shields.io/badge/-Linux-yellow?style=flat-square&logo=linux&logoColor=white" />
     </a>
   </div>


### PR DESCRIPTION
There is a missing `/` breaking the link.